### PR TITLE
Eliminated statically allocated array

### DIFF
--- a/src/wkline.c
+++ b/src/wkline.c
@@ -10,7 +10,15 @@ GThread *widget_threads[LENGTH(wkline_widgets)];
 gboolean
 update_widget (widget_data_t *widget_data) {
 	char *script_template = "if(typeof widgets!=='undefined'){try{widgets.update('%s',%s)}catch(e){console.log('Could not update widget: '+e)}}";
-	char script[4096];
+	int script_length = 0;
+	char *script;
+
+	// Get the length of the script payload.
+	script_length = snprintf(
+			NULL, 0, script_template, widget_data->widget, widget_data->data
+			);
+	// Add 1 for \0
+	script = malloc(script_length + 1);
 
 #ifdef DEBUG_JSON
 	wklog("Updating widget %s: %s", widget_data->widget, widget_data->data);
@@ -19,6 +27,7 @@ update_widget (widget_data_t *widget_data) {
 
 	webkit_web_view_execute_script(web_view, script);
 	free(widget_data);
+	free(script);
 
 	return FALSE; // only run once
 }

--- a/src/wkline.c
+++ b/src/wkline.c
@@ -10,7 +10,17 @@ GThread *widget_threads[LENGTH(wkline_widgets)];
 gboolean
 update_widget (widget_data_t *widget_data) {
 	char *script_template = "if(typeof widgets!=='undefined'){try{widgets.update('%s',%s)}catch(e){console.log('Could not update widget: '+e)}}";
-	char script[4096];
+	int script_length = 0;
+	char *script;
+
+	// Get the length of the script payload.
+	script_length = snprintf(NULL,
+							 0,
+				 			 script_template,
+				 			 widget_data->widget, 
+				 			 widget_data->data);
+	// Add 1 for \0
+	script = malloc(script_length + 1);
 
 #ifdef DEBUG_JSON
 	wklog("Updating widget %s: %s", widget_data->widget, widget_data->data);
@@ -19,6 +29,7 @@ update_widget (widget_data_t *widget_data) {
 
 	webkit_web_view_execute_script(web_view, script);
 	free(widget_data);
+	free(script);
 
 	return FALSE; // only run once
 }

--- a/src/wkline.h
+++ b/src/wkline.h
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <gdk/gdkx.h>
 #include <gtk/gtk.h>
 #include <webkit/webkit.h>


### PR DESCRIPTION
I eliminated the need for a statically sized array within update_widget() of src/wkline.c by using snprintf to get the string size, the allocating the needed amount by calling malloc.

Cheers,
nHurD
