### PR TITLE
Basic multi-monitor support.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,7 @@ AM_SILENT_RULES([yes])
 # Access the variables via GTK3_CFLAGS and GTK3_LIBS
 PKG_CHECK_MODULES([GTK3], [gtk+-3.0])
 PKG_CHECK_MODULES([WEBKIT], [webkitgtk-3.0])
-PKG_CHECK_MODULES([XCB], [xcb-util xcb-ewmh xcb-icccm])
+PKG_CHECK_MODULES([XCB], [xcb-util xcb-ewmh xcb-icccm xcb-randr])
 PKG_CHECK_MODULES([JSON_GLIB], [jansson])
 
 AC_CONFIG_FILES([

--- a/src/config.h
+++ b/src/config.h
@@ -1,3 +1,4 @@
+static const int wkline_monitor = 0; // indexed at 0
 static const int wkline_height = 26;
 static const char *wkline_theme_uri = "http://lokaltog.github.io/wkline-theme-default/";
 

--- a/src/wkline.c
+++ b/src/wkline.c
@@ -60,7 +60,14 @@ main (int argc, char *argv[]) {
 	xcb_ewmh_init_atoms_replies(ewmh, ewmh_cookie, NULL);
 
 	xcb_screen_t *screen = ewmh->screens[screen_nbr];
-	wk_dimensions_t dim = {.w = screen->width_in_pixels, .h = wkline_height};
+
+    xcb_randr_get_screen_resources_cookie_t screen_res_c = xcb_randr_get_screen_resources(conn, screen->root);
+    xcb_randr_get_screen_resources_reply_t *screen_res_r = xcb_randr_get_screen_resources_reply(conn, screen_res_c, NULL);
+    xcb_randr_crtc_t *randr_crtcs = xcb_randr_get_screen_resources_crtcs(screen_res_r);
+    xcb_randr_get_crtc_info_cookie_t crtc_info_c = xcb_randr_get_crtc_info(conn, randr_crtcs[0], XCB_CURRENT_TIME);
+    xcb_randr_get_crtc_info_reply_t *crtc_info_r = xcb_randr_get_crtc_info_reply(conn, crtc_info_c, NULL);
+
+	wk_dimensions_t dim = {.w = crtc_info_r->width, .h = wkline_height};
 
 	// init window
 	guint window_xid;

--- a/src/wkline.c
+++ b/src/wkline.c
@@ -61,37 +61,33 @@ main (int argc, char *argv[]) {
 
 	xcb_screen_t *screen = ewmh->screens[screen_nbr];
 
-    xcb_randr_get_screen_resources_cookie_t screen_res_c = xcb_randr_get_screen_resources(conn, screen->root);
-    xcb_randr_get_screen_resources_reply_t *screen_res_r = xcb_randr_get_screen_resources_reply(conn, screen_res_c, NULL);
-    xcb_randr_crtc_t *randr_crtcs = xcb_randr_get_screen_resources_crtcs(screen_res_r);
-
-    int i;
-    wk_display_info_t displays[screen_res_r->num_crtcs]; 
-    for (i = 0; i < screen_res_r->num_crtcs; i++) {
-        xcb_randr_get_crtc_info_cookie_t tmp_c = xcb_randr_get_crtc_info(conn, randr_crtcs[i], XCB_CURRENT_TIME);
-        xcb_randr_get_crtc_info_reply_t *tmp_r = xcb_randr_get_crtc_info_reply(conn, tmp_c, NULL);
-
-        displays[i].width = tmp_r->width;
-        displays[i].offset = tmp_r->x;
-    }
-
-    int comp(struct wk_display_info_t *a, struct wk_display_info_t *b) {
-        if (a->width > 0 && b->width > 0) {
-            if (a->offset == b->offset)
-                return 0;
-            else
-                if (a->offset < b->offset)
-                    return -1;
-                else
-                    return 1;
-        }
-    }
-
-    qsort(displays, screen_res_r->num_crtcs, sizeof(struct wk_display_info_t), comp);
-
-    i = 0;
-    for (i = 0; i < screen_res_r->num_crtcs; i++)
-        printf("\noffset : %d\nwidth : %d\n", displays[i].offset, displays[i].width);
+	xcb_randr_get_screen_resources_cookie_t screen_res_c = xcb_randr_get_screen_resources(conn, screen->root);
+	xcb_randr_get_screen_resources_reply_t *screen_res_r = xcb_randr_get_screen_resources_reply(conn, screen_res_c, NULL);
+	xcb_randr_crtc_t *randr_crtcs = xcb_randr_get_screen_resources_crtcs(screen_res_r);
+	
+	int i;
+	wk_display_info_t displays[screen_res_r->num_crtcs];
+	for (i = 0; i < screen_res_r->num_crtcs; i++) {
+		xcb_randr_get_crtc_info_cookie_t tmp_c = xcb_randr_get_crtc_info(conn, randr_crtcs[i], XCB_CURRENT_TIME);
+		xcb_randr_get_crtc_info_reply_t *tmp_r = xcb_randr_get_crtc_info_reply(conn, tmp_c, NULL);
+	
+		displays[i].width = tmp_r->width;
+		displays[i].offset = tmp_r->x;
+	}
+	
+	int comp(struct wk_display_info_t *a, struct wk_display_info_t *b) {
+		if (a->width > 0 && b->width > 0) {
+			if (a->offset == b->offset)
+				return 0;
+			else
+				if (a->offset < b->offset)
+					return -1;
+			else
+			    return 1;
+		}
+	}
+	
+	qsort(displays, screen_res_r->num_crtcs, sizeof(struct wk_display_info_t), comp);
 
 	wk_dimensions_t dim = {.w = displays[wkline_monitor].width, .h = wkline_height};
 

--- a/src/wkline.h
+++ b/src/wkline.h
@@ -1,6 +1,7 @@
 #include <gdk/gdkx.h>
 #include <gtk/gtk.h>
 #include <webkit/webkit.h>
+#include <xcb/randr.h>
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>

--- a/src/wkline.h
+++ b/src/wkline.h
@@ -12,4 +12,9 @@ typedef struct wk_dimensions_t {
 	int h;
 } wk_dimensions_t;
 
+typedef struct wk_display_info_t {
+    int width;
+    int offset;
+} wk_display_info_t;
+
 #define LENGTH(X) (sizeof X / sizeof X[0])


### PR DESCRIPTION
This fixes issue #16 by using the RandR XCB extension to get the width of the default display, rather than the default screen.  It also adds the `wkline_monitor` variable in config.h to specify a specific monitor for the statusline to appear on.

I've compiled the patch on a couple different systems of varying display setups and it seems to work fine on all of them.
