### PR TITLE
widgets: outputs json to console if set to debug

### DIFF
--- a/src/util/config.c
+++ b/src/util/config.c
@@ -65,3 +65,12 @@ wkline_widget_get_config (struct widget *self, const char *config_name) {
 
 	return object;
 }
+
+json_t*
+wkline_widget_get_config_silent (struct widget *self, const char *config_name) {
+	json_t *object;
+	object = json_object_get(self->config, "widgets_config");
+	object = json_object_get(object, self->name);
+	object = json_object_get(object, config_name);
+	return object;
+}

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -9,3 +9,4 @@ struct widget;
 json_t* load_config_file ();
 json_t* wkline_get_config (struct wkline *self, const char *config_name);
 json_t* wkline_widget_get_config (struct widget *self, const char *config_name);
+json_t* wkline_widget_get_config_silent (struct widget *self, const char *config_name);

--- a/src/widgets.c
+++ b/src/widgets.c
@@ -1,4 +1,5 @@
 #include "widgets.h"
+#include "util/config.h"
 #include "util/log.h"
 
 static pthread_t *widget_threads;
@@ -20,9 +21,9 @@ update_widget (struct widget *widget) {
 	/* Add 1 for \0 */
 	script = malloc(script_length + 1);
 
-#ifdef DEBUG_JSON
-	wklog("Updating widget %s: %s", widget->name, widget->data);
-#endif
+	if (wkline_widget_get_config_silent(widget, "debug") == json_true())
+		wklog("Updating widget %s: %s", widget->name, widget->data);
+	
 	sprintf(script, script_template, widget->name, widget->data);
 
 	webkit_web_view_execute_script(widget->web_view, script);


### PR DESCRIPTION
Widgets now report their json output if the debug key is set to "true" in config.json
under their respective "widgets_config" dictionary.

In the sample config the "desktops" and "volume" widgets are set up to debug.

Sample config : https://gist.github.com/5paceManSpiff/9454437
