### PR TITLE
Set override redirect

### DIFF
--- a/src/wkline.c
+++ b/src/wkline.c
@@ -35,6 +35,7 @@ wk_realize_handler (GtkWidget *window, gpointer user_data) {
 	gdkw = gtk_widget_get_window(GTK_WIDGET(window));
 	gdk_property_change(gdkw, atom, gdk_atom_intern("CARDINAL", FALSE),
 	                    32, GDK_PROP_MODE_REPLACE, (guchar*)vals, LENGTH(vals));
+    gdk_window_set_override_redirect(gdkw, TRUE);
 }
 
 int

--- a/src/wkline.c
+++ b/src/wkline.c
@@ -35,7 +35,7 @@ wk_realize_handler (GtkWidget *window, gpointer user_data) {
 	gdkw = gtk_widget_get_window(GTK_WIDGET(window));
 	gdk_property_change(gdkw, atom, gdk_atom_intern("CARDINAL", FALSE),
 	                    32, GDK_PROP_MODE_REPLACE, (guchar*)vals, LENGTH(vals));
-    gdk_window_set_override_redirect(gdkw, TRUE);
+	gdk_window_set_override_redirect(gdkw, TRUE);
 }
 
 int


### PR DESCRIPTION
This works under dwm (don't have monsterwm running atm and I need to get back to work :P) I'm not sure how it affects bspwm or other such wms that respect the ewmh hints. 
