### PR TITLE
main: command line overrides using getopt()

### DIFF
--- a/src/wkline.c
+++ b/src/wkline.c
@@ -14,6 +14,29 @@ wk_context_menu_cb (WebKitWebView *web_view, GtkWidget *window) {
 #endif
 
 static void
+parse_args (int argc, char *argv[], json_t *config) {
+	int opt;
+
+	while ((opt = getopt(argc, argv, "h:p:t:m:")) != -1) {
+		switch (opt) {
+			case 'h':
+				json_object_set(config, "height", json_integer(atoi(optarg)));
+				break;
+			case 'm':
+				json_object_set(config, "monitor", json_integer(atoi(optarg)));
+				break;
+			case 't':
+				json_object_set(config, "theme_uri", json_string(optarg));
+				break;
+			case 'p':
+				json_object_set(config, "position", json_string(optarg));
+				break;
+
+		}
+	}
+}
+
+static void
 wk_realize_handler (GtkWidget *window, gpointer user_data) {
 	struct wkline *wkline = user_data;
 	GdkAtom net_wm_strut_atom = gdk_atom_intern("_NET_WM_STRUT", FALSE);
@@ -110,6 +133,8 @@ main (int argc, char *argv[]) {
 		LOG_ERR("config file not found.");
 		goto config_err;
 	}
+
+	parse_args(argc, argv, wkline->config);
 
 	signal(SIGTERM, handle_interrupt);
 	signal(SIGINT, handle_interrupt);

--- a/src/wkline.h
+++ b/src/wkline.h
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <unistd.h>
 #include <gdk/gdkx.h>
 #include <gtk/gtk.h>
 #include <string.h>


### PR DESCRIPTION
I've implemented command line overrides in `wkline.c` using `getopt()`.  Should I move the `parse_args()` function to its own file in `/src/util`?
