### PR TITLE
build: remove -Werror when using the debug flag

### DIFF
--- a/wscript
+++ b/wscript
@@ -31,7 +31,7 @@ def configure(ctx):
 
 	# compiler options
 	if ctx.options.debug:
-		ctx.env.append_unique('CFLAGS', ['-g3', '-O0', '-Wall', '-Werror'])
+		ctx.env.append_unique('CFLAGS', ['-g3', '-O0', '-Wall'])
 		ctx.define('DEBUG', 1)
 	else:
 		ctx.env.append_unique('CFLAGS', ['-O3', '-Wall', '-Werror'])


### PR DESCRIPTION
What do you think of this?  I personally like to worry about warnings after I've implemented a feature and am preparing to submit a pull request.
