### PR TITLE
meta: added vim .swp files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build/
 .lock-waf*
 .waf*
+
+*.swp


### PR DESCRIPTION
Would you be opposed to adding vim temporary files to the .gitignore?  It allows me to use git a little less painfully while keeping my vim workflow open.
