### PR TITLE
widgets: added widget target in config.json

### DIFF
--- a/src/widgets.c
+++ b/src/widgets.c
@@ -165,9 +165,18 @@ window_object_cleared_cb (WebKitWebView *web_view, GParamSpec *pspec, void *cont
 
 	LOG_DEBUG("starting %i widget threads", widgets_len);
 	json_array_foreach(widgets, index, widget) {
-		widget_threads[index] = spawn_widget(wkline,
-		                                     context,
-		                                     json_object_get(widget, "config"),
-		                                     json_string_value(json_object_get(widget, "module")));
+		json_t *js_target = json_object_get(widget, "target");
+		if (js_target == NULL) {
+			widget_threads[index] = spawn_widget(wkline,
+							context,
+							json_object_get(widget, "config"),
+							json_string_value(json_object_get(widget, "module")));
+		} else {
+			LOG_DEBUG("yup");
+			widget_threads[index] = spawn_widget(wkline,
+							context,
+							json_object_get(widget, "config"),
+							json_string_value(json_object_get(widget, "target")));
+		}
 	}
 }


### PR DESCRIPTION
Added the string `target` under the `module` key in config.json will set the widgets name to the specified javascript callback name.  It should look something like this.

``` json
{
    "module": "desktops_ewmh",
    "target": "desktops",
    "config": {}
}
```
