### PR TITLE
widgets: separated widget name and widget callback

### DIFF
--- a/src/widgets.c
+++ b/src/widgets.c
@@ -30,6 +30,7 @@ init_widget_js_obj (void *context, struct widget *widget) {
 static pthread_t
 spawn_widget (struct wkline *wkline, void *context, json_t *config, const char *name) {
 	widget_main_t widget_main;
+	widget_type_t widget_type;
 	char libname[64];
 	snprintf(libname, 64, "libwidget_%s", name);
 	gchar *libpath = g_module_build_path(LIBDIR, libname);
@@ -47,6 +48,10 @@ spawn_widget (struct wkline *wkline, void *context, json_t *config, const char *
 		LOG_WARN("loading of '%s' (%s) failed: unable to load module symbol", libpath, name);
 
 		goto error;
+	}
+
+	if (g_module_symbol(lib, "widget_type", (void*)&widget_type)) {
+		widget->type = widget_type();
 	}
 
 	JSStaticFunction *js_staticfuncs = calloc(1, sizeof(JSStaticFunction));

--- a/src/widgets.h
+++ b/src/widgets.h
@@ -33,6 +33,7 @@ struct js_callback_data {
 
 struct widget {
 	char *name;
+	char *type;
 	json_t *config;
 	char *data;
 	struct wkline *wkline;
@@ -42,6 +43,7 @@ struct widget {
 };
 
 typedef void (*widget_main_t)(void*);
+typedef char* (*widget_type_t)();
 
 pthread_mutex_t update_mutex;
 pthread_cond_t update_cond;


### PR DESCRIPTION
This is the alternative implementation you mentioned in #61.  In order to set the widget type, you add a function named `widget_type` which returns a `char*` with the widget type.  It should look something like this...

``` c
char*
widget_type () {
    return "desktops";
}
```
