### PR TITLE
Add the mpris widget

### DIFF
--- a/src/widgets/now_playing_mpris.c
+++ b/src/widgets/now_playing_mpris.c
@@ -1,0 +1,35 @@
+#include "widgets.h"
+#include "now_playing_mpris.h"
+
+void*
+widget_main (struct widget *widget) {
+	struct widget_config config = widget_config_defaults;
+	widget_init_config_string(widget->config, "player_name", config.player_name);
+
+	gchar *player_name = (gchar *)config.player_name;
+	PlayerctlPlayer *player = NULL;
+
+	widget_epoll_init(widget);
+	while (true) {
+		if (!player)
+			player = playerctl_player_new(player_name, NULL);
+
+		if (player) {
+			char *artist = playerctl_player_get_artist(player, NULL);
+			char *title = playerctl_player_get_title(player, NULL);
+
+			if (artist || title)
+				widget_data_callback(widget, widget_data_arg_string(artist), widget_data_arg_string(title));
+
+			g_free(artist);
+			g_free(title);
+		}
+
+		widget_epoll_wait_goto(widget, 1, cleanup);
+	}
+
+cleanup:
+	g_object_unref(player);
+
+	return 0;
+}

--- a/src/widgets/now_playing_mpris.h
+++ b/src/widgets/now_playing_mpris.h
@@ -1,0 +1,7 @@
+#include <playerctl/playerctl.h>
+
+static struct widget_config {
+	const char *player_name;
+} widget_config_defaults = {
+	.player_name = NULL
+};

--- a/wscript
+++ b/wscript
@@ -48,6 +48,7 @@ def configure(ctx):
 	ctx.check_cfg(package='glib-2.0 gmodule-2.0', uselib_store='GLIB', args=['--cflags', '--libs'])
 	ctx.check_cfg(package='webkitgtk-3.0', uselib_store='WEBKITGTK', args=['--cflags', '--libs'])
 	ctx.check_cfg(package='jansson', uselib_store='JANSSON', args=['--cflags', '--libs'])
+	ctx.check_cfg(package='playerctl-1.0', uselib_store='PLAYERCTL', args=['--cflags', '--libs'])
 
 	# optdeps
 	ctx.check_cfg(package='alsa', uselib_store='ALSA', args=['--cflags', '--libs'], mandatory=False)
@@ -58,7 +59,7 @@ def configure(ctx):
 	ctx.check_cfg(package='xcb-util xcb-ewmh xcb-icccm', uselib_store='XCB', args=['--cflags', '--libs'], mandatory=False)
 
 def build(bld):
-	basedeps = ['GTK', 'GLIB', 'WEBKITGTK', 'JANSSON']
+	basedeps = ['GTK', 'GLIB', 'WEBKITGTK', 'JANSSON', 'PLAYERCTL']
 
 	# add build version/time defines
 	wkline_defines = [
@@ -69,6 +70,7 @@ def build(bld):
 
 	# widgets
 	bld.shlib(source='src/widgets/datetime.c', target='widget_datetime', use=basedeps, install_path=LIBDIR)
+	bld.shlib(source='src/widgets/now_playing_mpris.c', target='widget_now_playing_mpris', use=basedeps, install_path=LIBDIR)
 
 	if bld.is_defined('HAVE_ALSA'):
 		bld.shlib(source='src/widgets/volume.c', target='widget_volume', use=basedeps + ['ALSA'], install_path=LIBDIR)


### PR DESCRIPTION
The mpris widget displays the artist and title for any media player that
implements the MPRIS DBus Interface Specification such as vlc, spotify,
mplayer, and others.

For more information on MPRIS:

http://specifications.freedesktop.org/mpris-spec/latest/

Pass "player_name" to the config to connect to
org.mpris.MediaPlayer2.[PLAYER] on your DBus session. If no player is
passed, the widget will choose the first mpris-enabled player that
becomes available to get metadata from.
