### PR TITLE
widgets/now_playing_mpris: event-driven updates

### DIFF
--- a/src/widgets/now_playing_mpris.c
+++ b/src/widgets/now_playing_mpris.c
@@ -1,6 +1,36 @@
 #include "widgets.h"
 #include "now_playing_mpris.h"
 
+static int
+update_widget (struct widget *widget, PlayerctlPlayer *player) {
+	char *artist = playerctl_player_get_artist(player, NULL);
+	char *title = playerctl_player_get_title(player, NULL);
+
+	struct js_callback_arg args[2] = {
+		widget_data_arg_string(artist),
+		widget_data_arg_string(title),
+	};
+
+	struct js_callback_data data = {
+		.widget = widget,
+		.args = args,
+		2,
+	};
+
+	web_view_callback(&data);
+
+	g_free(artist);
+	g_free(title);
+
+	return 0;
+}
+
+static void
+on_metadata (PlayerctlPlayer *player, GVariant *e, gpointer user_data) {
+	struct widget *widget = user_data;
+	update_widget(widget, player);
+}
+
 void*
 widget_main (struct widget *widget) {
 	struct widget_config config = widget_config_defaults;
@@ -11,23 +41,16 @@ widget_main (struct widget *widget) {
 
 	widget_epoll_init(widget);
 	while (true) {
-		if (!player) {
-			player = playerctl_player_new(player_name, NULL);
-		}
+		player = playerctl_player_new(player_name, NULL);
 
 		if (player) {
-			char *artist = playerctl_player_get_artist(player, NULL);
-			char *title = playerctl_player_get_title(player, NULL);
+			g_signal_connect(player, "metadata", G_CALLBACK(on_metadata), widget);
 
-			if (artist || title) {
-				widget_data_callback(widget, widget_data_arg_string(artist), widget_data_arg_string(title));
-			}
-
-			g_free(artist);
-			g_free(title);
+			widget_epoll_wait_goto(widget, -1, cleanup);
+		} else {
+			/* keep trying until we find a player */
+			widget_epoll_wait_goto(widget, 1, cleanup);
 		}
-
-		widget_epoll_wait_goto(widget, 1, cleanup);
 	}
 
 cleanup:


### PR DESCRIPTION
Use the player "metadata" event rather than a polling interval for
updating the widget. This event should be emitted when the track
changes.

If no player is passed, the widget will poll DBus for players every
second until it finds one.
