### PR TITLE
Fix multi-monitor support.

### DIFF
--- a/src/candybar.c
+++ b/src/candybar.c
@@ -223,10 +223,10 @@ main (int argc, char *argv[]) {
 	gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(layout));
 
 	if (bar->position == BAR_POSITION_TOP) {
-		gtk_window_move(window, 0, 0);
+		gtk_window_move(window, dest.x, 0);
 	}
 	else if (bar->position == BAR_POSITION_BOTTOM) {
-		gtk_window_move(window, 0, dest.height - bar->height);
+		gtk_window_move(window, dest.x, dest.height - bar->height);
 	}
 
 	g_signal_connect(web_view, "context-menu", G_CALLBACK(wk_context_menu_cb), NULL);


### PR DESCRIPTION
Lokaltog/candybar@970366e5c90e750c562ee3906a3d2764584a0483 changes the relative position of the monitor to the screen, `dest.x`, to 0, preventing gtk from moving candybar from the most right screen to the desired monitor choice.

Though is a bit of a weird way of doing it, I'm not quite sure any others that would work.  Why was this change made initially?
