### PR TITLE
Add MPRIS javascript callbacks for music control.

### DIFF
--- a/src/widgets/now_playing_mpris.c
+++ b/src/widgets/now_playing_mpris.c
@@ -1,6 +1,17 @@
 #include "widgets.h"
 #include "now_playing_mpris.h"
 
+static JSValueRef
+widget_js_func_toggle (JSContextRef ctx, JSObjectRef func, JSObjectRef this, size_t argc, const JSValueRef argv[], JSValueRef *exc) {
+	LOG_DEBUG("toggling");
+	return JSValueMakeUndefined(ctx);
+}
+
+const JSStaticFunction widget_js_staticfuncs[] = {
+	{ "toggle", widget_js_func_toggle, kJSPropertyAttributeReadOnly },
+	{ NULL, NULL, 0 },
+};
+
 static int
 update_widget (struct widget *widget, PlayerctlPlayer *player) {
 	char *artist = playerctl_player_get_artist(player, NULL);

--- a/src/widgets/now_playing_mpris.c
+++ b/src/widgets/now_playing_mpris.c
@@ -7,9 +7,9 @@ widget_js_func_toggle (JSContextRef ctx, JSObjectRef func, JSObjectRef this, siz
 	playerctl_player_play_pause(player, NULL);
 
 	g_object_unref(player);
+
 	return JSValueMakeUndefined(ctx);
 }
-
 
 static JSValueRef
 widget_js_func_next (JSContextRef ctx, JSObjectRef func, JSObjectRef this, size_t argc, const JSValueRef argv[], JSValueRef *exc) {
@@ -17,6 +17,7 @@ widget_js_func_next (JSContextRef ctx, JSObjectRef func, JSObjectRef this, size_
 	playerctl_player_next(player, NULL);
 
 	g_object_unref(player);
+
 	return JSValueMakeUndefined(ctx);
 }
 
@@ -26,6 +27,7 @@ widget_js_func_previous (JSContextRef ctx, JSObjectRef func, JSObjectRef this, s
 	playerctl_player_previous(player, NULL);
 
 	g_object_unref(player);
+
 	return JSValueMakeUndefined(ctx);
 }
 

--- a/src/widgets/now_playing_mpris.c
+++ b/src/widgets/now_playing_mpris.c
@@ -3,12 +3,36 @@
 
 static JSValueRef
 widget_js_func_toggle (JSContextRef ctx, JSObjectRef func, JSObjectRef this, size_t argc, const JSValueRef argv[], JSValueRef *exc) {
-	LOG_DEBUG("toggling");
+	PlayerctlPlayer *player = playerctl_player_new(NULL, NULL);
+	playerctl_player_play_pause(player, NULL);
+
+	g_object_unref(player);
+	return JSValueMakeUndefined(ctx);
+}
+
+
+static JSValueRef
+widget_js_func_next (JSContextRef ctx, JSObjectRef func, JSObjectRef this, size_t argc, const JSValueRef argv[], JSValueRef *exc) {
+	PlayerctlPlayer *player = playerctl_player_new(NULL, NULL);
+	playerctl_player_next(player, NULL);
+
+	g_object_unref(player);
+	return JSValueMakeUndefined(ctx);
+}
+
+static JSValueRef
+widget_js_func_previous (JSContextRef ctx, JSObjectRef func, JSObjectRef this, size_t argc, const JSValueRef argv[], JSValueRef *exc) {
+	PlayerctlPlayer *player = playerctl_player_new(NULL, NULL);
+	playerctl_player_previous(player, NULL);
+
+	g_object_unref(player);
 	return JSValueMakeUndefined(ctx);
 }
 
 const JSStaticFunction widget_js_staticfuncs[] = {
 	{ "toggle", widget_js_func_toggle, kJSPropertyAttributeReadOnly },
+	{ "next", widget_js_func_next, kJSPropertyAttributeReadOnly },
+	{ "previous", widget_js_func_previous, kJSPropertyAttributeReadOnly },
 	{ NULL, NULL, 0 },
 };
 


### PR DESCRIPTION
This adds javascript callbacks for basic music control in the `now_playing_mpris` widget.  This is currently used in my similarly named branch for `candybar-theme-default`.
